### PR TITLE
Upgrade to Node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,5 +17,5 @@ outputs:
   token:
     description: 'An access token that can be used to call the GitHub API'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Node 16 is only supported till spring 2024 -> https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/